### PR TITLE
Do a recursive clone of the beman repository

### DIFF
--- a/reusable-beman-build-and-test.yml
+++ b/reusable-beman-build-and-test.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
       - name: Setup MSVC
         if: matrix.config.compiler == 'msvc'
         uses: TheMrMilchmann/setup-msvc-dev@v3


### PR DESCRIPTION
This is so beman::utf_view can use its mpark/wg21 submodule dependency.