### PR TITLE
Don't specify version-tagged version of gcov

### DIFF
--- a/reusable-beman-build-and-test.yml
+++ b/reusable-beman-build-and-test.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           cat > gcovr.cfg <<EOF
           root = $GITHUB_WORKSPACE
-          gcov-executable = gcov-${{ matrix.config.version }}
+          gcov-executable = gcov
           exclude = $GITHUB_WORKSPACE/build/.*
           exclude = $GITHUB_WORKSPACE/examples/.*
           exclude = $GITHUB_WORKSPACE/tests/.*


### PR DESCRIPTION
This breaks running coverage with trunk images and Gentoo links the right gcov anyway.