### PR TITLE
pre-commit: Always run on all files

### DIFF
--- a/reusable-beman-pre-commit.yml
+++ b/reusable-beman-pre-commit.yml
@@ -18,10 +18,6 @@ jobs:
         with:
           python-version: 3.13
 
-        # We wish to run pre-commit on all files instead of the changes
-        # only made in the push commit.
-        #
-        # So linting error persists when there's formatting problem.
       - uses: pre-commit/action@v3.0.1
 
   pre-commit-pr:
@@ -51,17 +47,7 @@ jobs:
         with:
           python-version: 3.13
 
-        # we only lint on the changed file in PR.
-      - name: Get Changed Files
-        id: changed-files
-        uses: tj-actions/changed-files@v45
-
-        # See:
-        # https://github.com/tj-actions/changed-files?tab=readme-ov-file#using-local-git-directory-
       - uses: pre-commit/action@v3.0.1
-        id: run-pre-commit
-        with:
-          extra_args: --files ${{ steps.changed-files.outputs.all_changed_files }}
 
         # Review dog posts the suggested change from pre-commit to the pr.
       - name: suggester / pre-commit


### PR DESCRIPTION
We're adding a job that updates the pre-commit configuration file to use newer linter versions. When these updates occur, it can cause existing files to become out of sync with what the linter wants, while those files do not show up in the list of changed files, causing CI false positives.

This commit addresses the issue by always running pre-commit on everything.