### PR TITLE
Add reusable workflow to update pre-commit

### DIFF
--- a/reusable-beman-update-pre-commit.yml
+++ b/reusable-beman-update-pre-commit.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Pre-commit auto-update
+
+on:
+  workflow_call:
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-autoupdate
+          title: Auto-update pre-commit hooks
+          commit-message: Auto-update pre-commit hooks
+          body: Update versions of tools in pre-commit configs to latest version
+          labels: dependencies


### PR DESCRIPTION
This is the reusable version of the workflow added by https://github.com/bemanproject/exemplar/commit/21d991b9185568771700921e859901899cb12943