### PR TITLE
Fix bug in beman-submodule check for multiple beman submodules

### DIFF
--- a/reusable-beman-submodule-check.yml
+++ b/reusable-beman-submodule-check.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/checkout@v4
       - name: beman submodule consistency check
         run: |
-          (set -o pipefail; ${{ inputs.infra_path }}/tools/beman-submodule/beman-submodule status | grep -qvF '+')
+          (set -eo pipefail; while read line ; do echo $line | grep -qvF '+' ; done < <(${{ inputs.infra_path }}/tools/beman-submodule/beman-submodule status))


### PR DESCRIPTION
The previous beman-submodule consistency check would work properly if there was a single beman-submodule. However, the `grep -qvF '+'` check would only end in error if all of the status lines started with '+', whereas the intent was that it should have ended in error if any of the status lines started with '+'. This meant that if there were multiple beman-submodules, and some, but not all of them were out of date, the check would erroneously succeed.

This commit addresses the issue by looping over all the lines of the beman-submodule status output and running a separate grep on each line.