### PR TITLE
Update build-and-test workflow not to run Coverage jobs on schedule

### DIFF
--- a/.github/workflows/reusable-beman-build-and-test.yml
+++ b/.github/workflows/reusable-beman-build-and-test.yml
@@ -150,7 +150,7 @@ jobs:
         shell: bash
         run: ctest --test-dir build --build-config ${{ steps.vars.outputs.build_config }} --output-on-failure
       - name: Generate Coverage Files
-        if: steps.vars.outputs.test_type == 'Coverage'
+        if: steps.vars.outputs.test_type == 'Coverage' && github.event_name != 'schedule'
         shell: bash
         run: |
           cat > gcovr.cfg <<EOF
@@ -167,7 +167,7 @@ jobs:
           gcovr --verbose --config gcovr.cfg .
           cat coverage.json
       - name: Upload Coverage Data to Coveralls
-        if: steps.vars.outputs.test_type == 'Coverage'
+        if: steps.vars.outputs.test_type == 'Coverage' && github.event_name != 'schedule'
         uses: coverallsapp/github-action@main
         with:
           file: coverage.json


### PR DESCRIPTION
Due to Coveralls flakiness, this resulted in complaints about automatic scheduled build issues being filed because the code coverage job failed to run. It's less useful to test code coverage in the scheduled build, so this change hardcodes them out in scheduled builds.