### PR TITLE
Add clang tidy reusable workflow

### DIFF
--- a/.github/workflows/reusable-beman-clang-tidy.yml
+++ b/.github/workflows/reusable-beman-clang-tidy.yml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: 'Beman clang-tidy run matrix'
+on:
+  workflow_call:
+    inputs:
+      matrix_config:
+        description: 'JSON array of {"options":"", "files":"", "upload_results": false, "continue_on_error": true} objects'
+        type: string
+        required: true
+jobs:
+  clang_tidy_matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        clang_tidy_args: ${{ fromJSON(inputs.matrix_config) }}
+    name: "clang-tidy on infra-containers-clang:latest"
+    runs-on: ubuntu-latest
+    container: ghcr.io/bemanproject/infra-containers-clang:latest
+    env:
+      CXX: /usr/local/bin/clang++
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Config cmake
+        run: |
+          cmake -B build -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: clang-tidy ${{ matrix.clang_tidy_args.files }}
+        continue-on-error: ${{ matrix.clang_tidy_args.continue_on_error || true }}
+        run: |
+          run-clang-tidy -p build ${{ matrix.clang_tidy_args.options }} ${{ matrix.clang_tidy_args.files }}
+
+      - name: Upload clang-tidy results
+        if: ${{ matrix.clang_tidy_args.upload_results || false }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-tidy-results
+          path: ${{env.BUILD_DIR}}/*.yaml
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -87,3 +87,18 @@ directories used by Beman repositories to deduplicate infrastructure.
 ## `reusable-beman-clang-tidy.yml`
 
 This provides a workflow for running clang-tidy on the `build` directory where it is expected to find the `compile_commands.json` file.
+
+Provides a reusable workflow that runs `clang-tidy` inside the `ghcr.io/bemanproject/infra-containers-clang:latest` container. It accepts a JSON `matrix_config` input (fields: `options`, `files`, `upload_results`, `continue_on_error`):
+
+```json
+[
+  {"options": "", "files": "examples", "upload_results": false},
+  {"options": "-checks='-*,bugprone-*'", "files": "examples", "upload_results": false},
+]
+```
+- `options`: These are command line options directly passed to `run-clang-tidy`.<br>The workflow itself will append `-p <build dir>` so it is not recommended to manually pass `-p <build dir>`.
+- `files`: This can be a directory or files or a path containing wildcards which are passed to `run-clang-tidy`.
+- `upload_results`: If set to true will upload all files matching `build/*.yaml` to the current workflow run.
+- `continue_on_error`: If set to true the clang-tidy check will not fail. If not specified automatically set to true.
+
+It then configures CMake to export `compile_commands.json` into a build directory, runs `run-clang-tidy` against that build tree, and can optionally upload YAML results as an artifact.

--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ requests and on push.
 This provides a workflow for checking consistency of
 [`beman-submodule`](https://github.com/bemanproject/infra/blob/main/tools/beman-submodule/README.md)
 directories used by Beman repositories to deduplicate infrastructure.
+
+## `reusable-beman-clang-tidy.yml`
+
+This provides a workflow for running clang-tidy on the `build` directory where it is expected to find the `compile_commands.json` file.


### PR DESCRIPTION
In this PR I add a reusable workflow to run clang-tidy in the `ghcr.io/bemanproject/infra-containers-clang:latest` container.

The workflow is intended to be used with `reusable-beman-build-and-test.yml`.
It will configure cmake to create the compile commands which is then consumed by `clang-tidy`.

