### PR TITLE
Skip pre-commit autoupdate for repos outside bemanproject org

### DIFF
--- a/.github/workflows/reusable-beman-update-pre-commit.yml
+++ b/.github/workflows/reusable-beman-update-pre-commit.yml
@@ -6,11 +6,12 @@ on:
   workflow_call:
     secrets:
       APP_ID:
-        required: true
+        required: false
       PRIVATE_KEY:
-        required: true
+        required: false
 jobs:
   auto-update:
+    if: github.repository_owner == 'bemanproject'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The workflow relies on organization secrets (APP_ID, PRIVATE_KEY) that are unavailable to forks and repos outside the bemanproject org. Mark the secrets as not required and add a job-level condition to skip the job when the repository owner is not bemanproject, so that the workflow is skipped rather than failed.

Fixes bemanproject/exemplar#330