### PR TITLE
Add missing step id for reviewdog in pre-commit PR job

### DIFF
--- a/.github/workflows/reusable-beman-pre-commit.yml
+++ b/.github/workflows/reusable-beman-pre-commit.yml
@@ -48,6 +48,7 @@ jobs:
           python-version: 3.13
 
       - uses: pre-commit/action@v3.0.1
+        id: run-pre-commit
 
         # Review dog posts the suggested change from pre-commit to the pr.
       - name: suggester / pre-commit


### PR DESCRIPTION
The reviewdog suggester step's condition references steps.run-pre-commit.conclusion, but the pre-commit action step never had id: run-pre-commit. This caused the condition to always evaluate to false, silently skipping reviewdog on every PR.