### PR TITLE
Skip Coveralls upload when coverage report has no source files

### DIFF
--- a/.github/workflows/reusable-beman-build-and-test.yml
+++ b/.github/workflows/reusable-beman-build-and-test.yml
@@ -169,8 +169,15 @@ jobs:
           git config --global --add safe.directory $GITHUB_WORKSPACE
           gcovr --verbose --config gcovr.cfg .
           cat coverage.json
-      - name: Upload Coverage Data to Coveralls
+      - name: Check if coverage data is empty
         if: steps.vars.outputs.test_type == 'Coverage' && github.event_name != 'schedule'
+        id: coverage_check
+        run: |
+          if jq -e '.source_files | length > 0' coverage.json > /dev/null 2>&1; then
+            echo "has_data=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload Coverage Data to Coveralls
+        if: steps.coverage_check.outputs.has_data == 'true'
         uses: coverallsapp/github-action@main
         with:
           file: coverage.json


### PR DESCRIPTION
Empty libraries (e.g. newly created repos) produce coverage.json with no source_files, causing the Coveralls action to fail with "Nothing to report". Gate the upload on a prior check for reportable data.