### PR TITLE
Update actions/checkout version

### DIFF
--- a/.github/workflows/reusable-beman-build-and-test.yml
+++ b/.github/workflows/reusable-beman-build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - id: set-matrix
         shell: python
         run: |
@@ -65,7 +65,7 @@ jobs:
     container: ${{ matrix.config.image }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Setup MSVC

--- a/.github/workflows/reusable-beman-build-and-test.yml
+++ b/.github/workflows/reusable-beman-build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: set-matrix
         shell: python
         run: |
@@ -65,7 +65,7 @@ jobs:
     container: ${{ matrix.config.image }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
       - name: Setup MSVC

--- a/.github/workflows/reusable-beman-create-issue-when-fault.yml
+++ b/.github/workflows/reusable-beman-create-issue-when-fault.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # See https://github.com/cli/cli/issues/5075
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Create issue
         run: |
           issue_num=$(gh issue list -s open -S "[SCHEDULED-BUILD] Build & Test failure" -L 1 --json number | jq 'if length == 0 then -1 else .[0].number end')

--- a/.github/workflows/reusable-beman-create-issue-when-fault.yml
+++ b/.github/workflows/reusable-beman-create-issue-when-fault.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # See https://github.com/cli/cli/issues/5075
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Create issue
         run: |
           issue_num=$(gh issue list -s open -S "[SCHEDULED-BUILD] Build & Test failure" -L 1 --json number | jq 'if length == 0 then -1 else .[0].number end')

--- a/.github/workflows/reusable-beman-pre-commit.yml
+++ b/.github/workflows/reusable-beman-pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
         # pull_request_target checkout the base of the repo
         # We need to checkout the actual pr to lint the changes.

--- a/.github/workflows/reusable-beman-pre-commit.yml
+++ b/.github/workflows/reusable-beman-pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
         # pull_request_target checkout the base of the repo
         # We need to checkout the actual pr to lint the changes.

--- a/.github/workflows/reusable-beman-preset-test.yml
+++ b/.github/workflows/reusable-beman-preset-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.presets.runner || 'ubuntu-latest' }}
     container: ${{ matrix.presets.image }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup build environment
         if: matrix.presets.runner
         uses: lukka/get-cmake@latest

--- a/.github/workflows/reusable-beman-preset-test.yml
+++ b/.github/workflows/reusable-beman-preset-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.presets.runner || 'ubuntu-latest' }}
     container: ${{ matrix.presets.image }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup build environment
         if: matrix.presets.runner
         uses: lukka/get-cmake@latest

--- a/.github/workflows/reusable-beman-submodule-check.yml
+++ b/.github/workflows/reusable-beman-submodule-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Install beman-submodule
         run: pip install beman-submodule
       - name: beman submodule consistency check

--- a/.github/workflows/reusable-beman-submodule-check.yml
+++ b/.github/workflows/reusable-beman-submodule-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install beman-submodule
         run: pip install beman-submodule
       - name: beman submodule consistency check

--- a/.github/workflows/reusable-beman-update-pre-commit.yml
+++ b/.github/workflows/reusable-beman-update-pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'bemanproject'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/reusable-beman-update-pre-commit.yml
+++ b/.github/workflows/reusable-beman-update-pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'bemanproject'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
Using this reusable CI emits the following warning:

Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Update the versions of actions/checkout so that these don't break in the near future 