### PR TITLE
Bump TheMrMilchmann/setup-msvc-dev to v4

### DIFF
--- a/.github/workflows/reusable-beman-build-and-test.yml
+++ b/.github/workflows/reusable-beman-build-and-test.yml
@@ -70,7 +70,7 @@ jobs:
           submodules: 'recursive'
       - name: Setup MSVC
         if: matrix.config.compiler == 'msvc'
-        uses: TheMrMilchmann/setup-msvc-dev@v3
+        uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
           arch: x64
       - name: Setup Macos

--- a/.github/workflows/reusable-beman-preset-test.yml
+++ b/.github/workflows/reusable-beman-preset-test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: lukka/get-cmake@latest
       - name: Setup MSVC
         if: startsWith(matrix.presets.runner, 'windows')
-        uses: TheMrMilchmann/setup-msvc-dev@v3
+        uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
           arch: x64
       - name: Configure preset verbose


### PR DESCRIPTION
This ensures that we no longer get CI warnings about deprecated Node.js v20 actions for these jobs.