### PR TITLE
Bump actions/setup-python to v6

### DIFF
--- a/.github/workflows/reusable-beman-pre-commit.yml
+++ b/.github/workflows/reusable-beman-pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13
 
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13
 

--- a/.github/workflows/reusable-beman-update-pre-commit.yml
+++ b/.github/workflows/reusable-beman-update-pre-commit.yml
@@ -22,7 +22,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13
       - name: Install pre-commit


### PR DESCRIPTION
This is another commit related to Node.js v20 action deprecations.