### PR TITLE
Ignore GCOV parse errors

### DIFF
--- a/.github/workflows/reusable-beman-build-and-test.yml
+++ b/.github/workflows/reusable-beman-build-and-test.yml
@@ -178,6 +178,8 @@ jobs:
           coveralls = $GITHUB_WORKSPACE/coverage.json
           coveralls-pretty = yes
           merge-mode-functions = separate
+          gcov-ignore-parse-errors = suspicious_hits.warn_once_per_file
+          gcov-ignore-parse-errors = negative_hits.warn_once_per_file
           EOF
           git config --global --add safe.directory $GITHUB_WORKSPACE
           gcovr --verbose --config gcovr.cfg .


### PR DESCRIPTION
I have been having pretty consistent errors from suspicious and negative hits. Example is here: https://github.com/eisenwave/std-big-int/actions/runs/25514045712/job/74880294671#step:13:1880. Ignore these parse errors rather than panicking.

CC: @eisenwave