### PR TITLE
Pin CMake version for MSVC/AppleClang CI jobs

### DIFF
--- a/.github/workflows/reusable-beman-build-and-test.yml
+++ b/.github/workflows/reusable-beman-build-and-test.yml
@@ -80,6 +80,8 @@ jobs:
       - name: Setup latest CMake and Ninja
         if: matrix.config.compiler == 'msvc' || matrix.config.compiler == 'appleclang'
         uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 4.3.3
       - name: Print installed software
         shell: bash
         run: |


### PR DESCRIPTION
Pulling the latest CMake version had been causing CI failures for MSVC modules builds, since Beman libraries depend on a file we maintain in infra/ that maps CMake versions to the
CMAKE_EXPERIMENTAL_CXX_IMPORT_STD UUID, and lukka/get-cmake was pulling in the latest version of CMake before we had time to update the file. This commit prevents the problem going forward by pinning the CMake version.